### PR TITLE
Fix Services namespace

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -20,13 +20,13 @@ public class Bluetooth.Indicator : Wingpanel.Indicator {
 
     private Bluetooth.Widgets.PopoverWidget popover_widget;
     private Bluetooth.Widgets.DisplayWidget dynamic_icon;
-    private Bluetooth.Services.ObjectManager object_manager;
+    private BluetoothIndicator.Services.ObjectManager object_manager;
     public Indicator (bool is_in_session) {
         Object (code_name: Wingpanel.Indicator.BLUETOOTH,
                 display_name: _("bluetooth"),
                 description:_("The bluetooth indicator"));
         this.is_in_session = is_in_session;
-        object_manager = new Services.ObjectManager ();
+        object_manager = new BluetoothIndicator.Services.ObjectManager ();
         object_manager.bind_property ("has-object", this, "visible", GLib.BindingFlags.SYNC_CREATE);
 
         if (object_manager.has_object) {

--- a/src/Services/Adapter.vala
+++ b/src/Services/Adapter.vala
@@ -16,7 +16,7 @@
  */
 
 [DBus (name = "org.bluez.Adapter1")]
-public interface Bluetooth.Services.Adapter : Object {
+public interface BluetoothIndicator.Services.Adapter : Object {
     public abstract void remove_device (ObjectPath device) throws IOError;
     public abstract void set_discovery_filter (HashTable<string, Variant> properties) throws IOError;
     public abstract void start_discovery () throws IOError;

--- a/src/Services/Device.vala
+++ b/src/Services/Device.vala
@@ -16,7 +16,7 @@
  */
 
 [DBus (name = "org.bluez.Device1")]
-public interface Bluetooth.Services.Device : Object {
+public interface BluetoothIndicator.Services.Device : Object {
     public abstract void cancel_pairing () throws IOError;
     public abstract void connect () throws IOError;
     public abstract void connect_profile (string UUID) throws IOError;

--- a/src/Services/Manager.vala
+++ b/src/Services/Manager.vala
@@ -16,36 +16,32 @@
  */
 
 [DBus (name = "org.freedesktop.DBus.ObjectManager")]
-public interface Bluetooth.Services.DBusInterface : Object {
+public interface BluetoothIndicator.Services.DBusInterface : Object {
     public signal void interfaces_added (ObjectPath object_path, HashTable<string, HashTable<string, Variant>> param);
     public signal void interfaces_removed (ObjectPath object_path, string[] string_array);
 
     public abstract HashTable<ObjectPath, HashTable<string, HashTable<string, Variant>>> get_managed_objects () throws IOError;
 }
 
-public class Bluetooth.Services.ObjectManager : Object {
+public class BluetoothIndicator.Services.ObjectManager : Object {
     public signal void global_state_changed (bool enabled, bool connected);
-    public signal void adapter_added (Bluetooth.Services.Adapter adapter);
-    public signal void adapter_removed (Bluetooth.Services.Adapter adapter);
-    public signal void device_added (Bluetooth.Services.Device adapter);
-    public signal void device_removed (Bluetooth.Services.Device adapter);
+    public signal void adapter_added (BluetoothIndicator.Services.Adapter adapter);
+    public signal void adapter_removed (BluetoothIndicator.Services.Adapter adapter);
+    public signal void device_added (BluetoothIndicator.Services.Device adapter);
+    public signal void device_removed (BluetoothIndicator.Services.Device adapter);
 
     public bool has_object { get; private set; default = false; }
 
     private Settings settings;
-    private Bluetooth.Services.DBusInterface object_interface;
-    private Gee.HashMap<string, Bluetooth.Services.Adapter> adapters;
-    private Gee.HashMap<string, Bluetooth.Services.Device> devices;
-
-    public ObjectManager () {
-        
-    }
+    private BluetoothIndicator.Services.DBusInterface object_interface;
+    private Gee.HashMap<string, BluetoothIndicator.Services.Adapter> adapters;
+    private Gee.HashMap<string, BluetoothIndicator.Services.Device> devices;
 
     construct {
-        adapters = new Gee.HashMap<string, Bluetooth.Services.Adapter> (null, null);
-        devices = new Gee.HashMap<string, Bluetooth.Services.Device> (null, null);
+        adapters = new Gee.HashMap<string, BluetoothIndicator.Services.Adapter> (null, null);
+        devices = new Gee.HashMap<string, BluetoothIndicator.Services.Device> (null, null);
         settings = new Settings ("org.pantheon.desktop.wingpanel.indicators.bluetooth");
-        Bus.get_proxy.begin<Bluetooth.Services.DBusInterface> (BusType.SYSTEM, "org.bluez", "/", DBusProxyFlags.NONE, null, (obj, res) => {
+        Bus.get_proxy.begin<BluetoothIndicator.Services.DBusInterface> (BusType.SYSTEM, "org.bluez", "/", DBusProxyFlags.NONE, null, (obj, res) => {
             try {
                 object_interface = Bus.get_proxy.end (res);
                 object_interface.get_managed_objects ().foreach (add_path);
@@ -61,7 +57,7 @@ public class Bluetooth.Services.ObjectManager : Object {
     private void add_path (ObjectPath path, HashTable<string, HashTable<string, Variant>> param) {
         if ("org.bluez.Adapter1" in param) {
             try {
-                Bluetooth.Services.Adapter adapter = Bus.get_proxy_sync (BusType.SYSTEM, "org.bluez", path, DBusProxyFlags.GET_INVALIDATED_PROPERTIES);
+                BluetoothIndicator.Services.Adapter adapter = Bus.get_proxy_sync (BusType.SYSTEM, "org.bluez", path, DBusProxyFlags.GET_INVALIDATED_PROPERTIES);
                 lock (adapters) {
                     adapters.set (path, adapter);
                 }
@@ -79,7 +75,7 @@ public class Bluetooth.Services.ObjectManager : Object {
             }
         } else if ("org.bluez.Device1" in param) {
             try {
-                Bluetooth.Services.Device device = Bus.get_proxy_sync (BusType.SYSTEM, "org.bluez", path, DBusProxyFlags.GET_INVALIDATED_PROPERTIES);
+                BluetoothIndicator.Services.Device device = Bus.get_proxy_sync (BusType.SYSTEM, "org.bluez", path, DBusProxyFlags.GET_INVALIDATED_PROPERTIES);
                 if (device.paired) {
                     lock (devices) {
                         devices.set (path, device);
@@ -139,19 +135,19 @@ public class Bluetooth.Services.ObjectManager : Object {
         }
     }
 
-    public Gee.Collection<Bluetooth.Services.Adapter> get_adapters () {
+    public Gee.Collection<BluetoothIndicator.Services.Adapter> get_adapters () {
         lock (adapters) {
             return adapters.values;
         }
     }
 
-    public Gee.Collection<Bluetooth.Services.Device> get_devices () {
+    public Gee.Collection<BluetoothIndicator.Services.Device> get_devices () {
         lock (devices) {
             return devices.values;
         }
     }
 
-    public Bluetooth.Services.Adapter? get_adapter_from_path (string path) {
+    public BluetoothIndicator.Services.Adapter? get_adapter_from_path (string path) {
         lock (adapters) {
             return adapters.get (path);
         }

--- a/src/Widgets/Device.vala
+++ b/src/Widgets/Device.vala
@@ -17,15 +17,15 @@
 
 public class Bluetooth.Widgets.Device : Wingpanel.Widgets.Container {
     private const string DEFAULT_ICON = "bluetooth";
-    public signal void show_device (Bluetooth.Services.Device device);
+    public signal void show_device (BluetoothIndicator.Services.Device device);
 
-    public Bluetooth.Services.Device device;
+    public BluetoothIndicator.Services.Device device;
     private Gtk.Label name_label;
     private Gtk.Label status_label;
     private Gtk.Spinner spinner;
     private Gtk.Image icon_image;
 
-    public Device (Bluetooth.Services.Device device) {
+    public Device (BluetoothIndicator.Services.Device device) {
         this.device = device;
         name_label = new Gtk.Label ("<b>%s</b>".printf (device.name));
         name_label.halign = Gtk.Align.START;

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -16,7 +16,7 @@
  */
 
 public class Bluetooth.Widgets.DisplayWidget : Gtk.Image {
-    public DisplayWidget (Bluetooth.Services.ObjectManager object_manager) {
+    public DisplayWidget (BluetoothIndicator.Services.ObjectManager object_manager) {
         icon_size = Gtk.IconSize.LARGE_TOOLBAR;
         set_icon (object_manager.get_global_state (), object_manager.get_connected ());
 

--- a/src/Widgets/PopoverWidget.vala
+++ b/src/Widgets/PopoverWidget.vala
@@ -20,7 +20,7 @@ public class Bluetooth.Widgets.PopoverWidget : Gtk.Stack {
     private Bluetooth.Widgets.MainView main_view;
     private Bluetooth.Widgets.DiscoveryView discovery_view;
 
-    public PopoverWidget (Bluetooth.Services.ObjectManager object_manager, bool is_in_session) {
+    public PopoverWidget (BluetoothIndicator.Services.ObjectManager object_manager, bool is_in_session) {
         transition_type = Gtk.StackTransitionType.SLIDE_LEFT_RIGHT;
         main_view = new Bluetooth.Widgets.MainView (object_manager, is_in_session);
         discovery_view = new Bluetooth.Widgets.DiscoveryView (object_manager);

--- a/src/Widgets/Views/DiscoveryView.vala
+++ b/src/Widgets/Views/DiscoveryView.vala
@@ -19,8 +19,8 @@ public class Bluetooth.Widgets.DiscoveryView : Gtk.Box {
     public Gtk.Button back_button;
     private Gtk.Grid device_grid;
 
-    unowned Bluetooth.Services.ObjectManager object_manager;
-    public DiscoveryView (Bluetooth.Services.ObjectManager object_manager) {
+    unowned BluetoothIndicator.Services.ObjectManager object_manager;
+    public DiscoveryView (BluetoothIndicator.Services.ObjectManager object_manager) {
         this.object_manager = object_manager;
     }
 

--- a/src/Widgets/Views/MainView.vala
+++ b/src/Widgets/Views/MainView.vala
@@ -17,7 +17,7 @@
 
 public class Bluetooth.Widgets.MainView : Gtk.Box {
     public signal void request_close ();
-    public signal void device_requested (Bluetooth.Services.Device device);
+    public signal void device_requested (BluetoothIndicator.Services.Device device);
     public signal void discovery_requested ();
 
     private Wingpanel.Widgets.Button show_settings_button;
@@ -26,7 +26,7 @@ public class Bluetooth.Widgets.MainView : Gtk.Box {
     private Gtk.Box devices_box;
     private Gtk.Revealer revealer;
 
-    public MainView (Bluetooth.Services.ObjectManager object_manager, bool is_in_session) {
+    public MainView (BluetoothIndicator.Services.ObjectManager object_manager, bool is_in_session) {
         orientation = Gtk.Orientation.VERTICAL;
 
         main_switch = new Wingpanel.Widgets.Switch (_("Bluetooth"), object_manager.get_global_state ());
@@ -113,7 +113,7 @@ public class Bluetooth.Widgets.MainView : Gtk.Box {
         devices_box.visible = !devices_box.no_show_all;
     }
 
-    private void add_device (Bluetooth.Services.Device device) {
+    private void add_device (BluetoothIndicator.Services.Device device) {
         var device_widget = new Bluetooth.Widgets.Device (device);
         devices_box.add (device_widget);
 


### PR DESCRIPTION
Fix colliding namespaces between the Bluetooth indicator and the plug. When wingpanel loads all of the indicators, Slingshot loads all the plugs using libswitchboard including the Bluetooth plug and GLib registers a Bluetooth.Services namespace and it's classes. After that wingpanel begins to load the Bluetooth indicator but the indicator fails to create objects from this namespace because their names are already used by another library. This leads to some pretty bad behaviour and fatal warnings in terminal.