### PR TITLE
PopoverWidget: Use Revealer when add/remove devices

### DIFF
--- a/src/Widgets/PopoverWidget.vala
+++ b/src/Widgets/PopoverWidget.vala
@@ -20,8 +20,6 @@ public class Bluetooth.Widgets.PopoverWidget : Gtk.Box {
     public signal void device_requested (BluetoothIndicator.Services.Device device);
     public signal void discovery_requested ();
 
-    private Wingpanel.Widgets.Separator device_box_separator;
-    private Gtk.ModelButton show_settings_button;
     private Wingpanel.Widgets.Switch main_switch;
     private Gtk.Box devices_box;
     private Gtk.Revealer revealer;
@@ -33,20 +31,19 @@ public class Bluetooth.Widgets.PopoverWidget : Gtk.Box {
         main_switch.get_style_context ().add_class ("h4");
 
         devices_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
-        device_box_separator = new Wingpanel.Widgets.Separator ();
 
         var scroll_box = new Wingpanel.Widgets.AutomaticScrollBox ();
         scroll_box.hscrollbar_policy = Gtk.PolicyType.NEVER;
         scroll_box.add (devices_box);
 
         var revealer_content = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
-        revealer_content.add (device_box_separator);
+        revealer_content.add (new Wingpanel.Widgets.Separator ());
         revealer_content.add (scroll_box);
 
         revealer = new Gtk.Revealer ();
         revealer.add (revealer_content);
 
-        show_settings_button = new Gtk.ModelButton ();
+        var show_settings_button = new Gtk.ModelButton ();
         show_settings_button.text = _("Bluetooth Settings…");
 
         add (main_switch);
@@ -97,20 +94,21 @@ public class Bluetooth.Widgets.PopoverWidget : Gtk.Box {
 
     private void update_ui_state (bool state) {
         main_switch.set_active (state);
-        revealer.reveal_child = state;
+        update_devices_box_visible ();
     }
 
     private void update_devices_box_visible () {
-        devices_box.no_show_all = (devices_box.get_children ().length () <= 0);
-        devices_box.visible = !devices_box.no_show_all;
-
-        device_box_separator.no_show_all = devices_box.no_show_all;
-        device_box_separator.visible = !devices_box.no_show_all;
+        if (devices_box.get_children ().length () >= 1) {
+            revealer.reveal_child = main_switch.get_active ();
+        } else {
+            revealer.reveal_child = false;
+        }
     }
 
     private void add_device (BluetoothIndicator.Services.Device device) {
         var device_widget = new Bluetooth.Widgets.Device (device);
         devices_box.add (device_widget);
+        devices_box.show_all ();
 
         update_devices_box_visible ();
 


### PR DESCRIPTION
Instead of using show/no_show, use the already existing revealer to hide/show the devices and separator when adding and removing devices