### PR TITLE
Consistently namespace everything as BluetoothIndicator

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -15,12 +15,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-public class Bluetooth.Indicator : Wingpanel.Indicator {
+public class BluetoothIndicator.Indicator : Wingpanel.Indicator {
     public bool is_in_session { get; construct; default = false; }
 
-    private Bluetooth.Widgets.PopoverWidget popover_widget;
-    private Bluetooth.Widgets.DisplayWidget dynamic_icon;
-    private BluetoothIndicator.Services.ObjectManager object_manager;
+    private Widgets.PopoverWidget popover_widget;
+    private Widgets.DisplayWidget dynamic_icon;
+    private Services.ObjectManager object_manager;
 
     public Indicator (bool is_in_session) {
         Object (
@@ -48,7 +48,7 @@ public class Bluetooth.Indicator : Wingpanel.Indicator {
 
     public override Gtk.Widget get_display_widget () {
         if (dynamic_icon == null) {
-            dynamic_icon = new Bluetooth.Widgets.DisplayWidget (object_manager);
+            dynamic_icon = new Widgets.DisplayWidget (object_manager);
         }
 
         return dynamic_icon;
@@ -56,7 +56,7 @@ public class Bluetooth.Indicator : Wingpanel.Indicator {
 
     public override Gtk.Widget? get_widget () {
         if (popover_widget == null) {
-            popover_widget = new Bluetooth.Widgets.PopoverWidget (object_manager, is_in_session);
+            popover_widget = new Widgets.PopoverWidget (object_manager, is_in_session);
             popover_widget.request_close.connect (() => {
                 close ();
             });
@@ -75,7 +75,7 @@ public class Bluetooth.Indicator : Wingpanel.Indicator {
 
 public Wingpanel.Indicator get_indicator (Module module, Wingpanel.IndicatorManager.ServerType server_type) {
     debug ("Activating Bluetooth Indicator");
-    var indicator = new Bluetooth.Indicator (server_type == Wingpanel.IndicatorManager.ServerType.SESSION);
+    var indicator = new BluetoothIndicator.Indicator (server_type == Wingpanel.IndicatorManager.ServerType.SESSION);
 
     return indicator;
 }

--- a/src/Widgets/Device.vala
+++ b/src/Widgets/Device.vala
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-public class Bluetooth.Widgets.Device : Wingpanel.Widgets.Container {
+public class BluetoothIndicator.Widgets.Device : Wingpanel.Widgets.Container {
     private const string DEFAULT_ICON = "bluetooth";
     public signal void show_device (BluetoothIndicator.Services.Device device);
 

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-public class Bluetooth.Widgets.DisplayWidget : Gtk.Spinner {
+public class BluetoothIndicator.Widgets.DisplayWidget : Gtk.Spinner {
     private Gtk.StyleContext style_context;
 
     public DisplayWidget (BluetoothIndicator.Services.ObjectManager object_manager) {

--- a/src/Widgets/PopoverWidget.vala
+++ b/src/Widgets/PopoverWidget.vala
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-public class Bluetooth.Widgets.PopoverWidget : Gtk.Box {
+public class BluetoothIndicator.Widgets.PopoverWidget : Gtk.Box {
     public signal void request_close ();
     public signal void device_requested (BluetoothIndicator.Services.Device device);
     public signal void discovery_requested ();
@@ -83,8 +83,8 @@ public class Bluetooth.Widgets.PopoverWidget : Gtk.Box {
 
         object_manager.device_removed.connect ((device) => {
             devices_box.get_children ().foreach ((child) => {
-                var device_child = child as Bluetooth.Widgets.Device;
-                if (device_child != null && BluetoothIndicator.Services.ObjectManager.compare_devices (device_child.device, device)) {
+                var device_child = child as Widgets.Device;
+                if (device_child != null && Services.ObjectManager.compare_devices (device_child.device, device)) {
                     device_child.destroy ();
                 }
             });
@@ -109,7 +109,7 @@ public class Bluetooth.Widgets.PopoverWidget : Gtk.Box {
     }
 
     private void add_device (BluetoothIndicator.Services.Device device) {
-        var device_widget = new Bluetooth.Widgets.Device (device);
+        var device_widget = new Widgets.Device (device);
         devices_box.add (device_widget);
 
         update_devices_box_visible ();


### PR DESCRIPTION
Instead of mixing `Bluetooth` and `BluetoothIndicator`