### PR TITLE
Always enable use of fallback icon

### DIFF
--- a/src/Widgets/Device.vala
+++ b/src/Widgets/Device.vala
@@ -98,7 +98,6 @@ public class BluetoothIndicator.Widgets.Device : Wingpanel.Widgets.Container {
             status_label.label = _("Not Connected");
         }
 
-        icon_image.icon_name = device.icon;
-
+        icon_image.icon_name = device.icon == null ? DEFAULT_ICON : device.icon;
     }
 }


### PR DESCRIPTION
We didn't always fallback to the bluetooth icon when a device didn't have a icon, causing:
![screenshot from 2019-01-31 01 41 17](https://user-images.githubusercontent.com/523210/52024573-98c8c400-2501-11e9-9e3d-690c6e09f602.png)

This PR also adds the fallback to the update function, resulting in:
![screenshot from 2019-01-31 02 36 25](https://user-images.githubusercontent.com/523210/52024602-aaaa6700-2501-11e9-9f42-de5c426b2b44.png)

Fixes #71