### PR TITLE
Horizontal margins tweak

### DIFF
--- a/src/Widgets/Device.vala
+++ b/src/Widgets/Device.vala
@@ -63,8 +63,7 @@ public class BluetoothIndicator.Widgets.Device : Gtk.ListBoxRow {
 
         var grid = new Gtk.Grid ();
         grid.column_spacing = 6;
-        grid.margin_start = 6;
-        grid.margin_end = 12;
+        grid.margin_end = 6;
         grid.attach (overlay, 0, 0, 1, 2);
         grid.attach (name_label, 1, 0, 2, 1);
         grid.attach (status_label, 1, 1, 1, 1);


### PR DESCRIPTION
A small tweak to the horizontal margins:

Before #79, after, after longer name:
![montage](https://user-images.githubusercontent.com/523210/70642319-49821280-1c3f-11ea-9a89-c3bef5e3a2ed.png)

Comparison before  #79, after, audio, power:
![montage](https://user-images.githubusercontent.com/523210/70642309-4424c800-1c3f-11ea-86e9-5ab314c7686c.png)

