### PR TITLE
Add indicator tooltip

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You'll need the following dependencies:
 
     gobject-introspection
     libglib2.0-dev
-    libgranite-dev
+    libgranite-dev >= 6.0.0
     libnotify-dev
     libwingpanel-dev
     meson

--- a/meson.build
+++ b/meson.build
@@ -36,7 +36,7 @@ shared_module(
     dependencies: [
         dependency('glib-2.0'),
         dependency('gobject-2.0'),
-        dependency('granite'),
+        dependency('granite', version: '>=6.0.0'),
         dependency('gtk+-3.0'),
         dependency('libnotify'),
         wingpanel_dep

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2015-2018 elementary LLC. (https://elementary.io)
+ * Copyright (c) 2015-2021 elementary LLC. (https://elementary.io)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Library General Public License as published by

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -65,17 +65,28 @@ public class BluetoothIndicator.Widgets.DisplayWidget : Gtk.Spinner {
     private void update_icon () {
         var state = object_manager.is_powered;
         var connected = object_manager.is_connected;
+        string description;
+        string context;
 
         if (state) {
             style_context.remove_class ("disabled");
+            context = _("Middle-click to disable bluetooth");
             if (connected) {
                 style_context.add_class ("paired");
+                description = _("Bluetooth connected");
             } else {
                 style_context.remove_class ("paired");
+                description = _("Bluetooth is on");
             }
         } else {
             style_context.remove_class ("paired");
             style_context.add_class ("disabled");
+            description = _("Bluetooth is off");
+            context = _("Middle-click to enable bluetooth");
         }
+
+        tooltip_markup = "%s\n%s".printf (
+            description, Granite.TOOLTIP_SECONDARY_TEXT_MARKUP.printf (context)
+        );
     }
 }

--- a/src/Widgets/PopoverWidget.vala
+++ b/src/Widgets/PopoverWidget.vala
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2015-2018 elementary LLC. (https://elementary.io)
+ * Copyright (c) 2015-2021 elementary LLC. (https://elementary.io)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Library General Public License as published by

--- a/src/Widgets/PopoverWidget.vala
+++ b/src/Widgets/PopoverWidget.vala
@@ -50,8 +50,13 @@ public class BluetoothIndicator.Widgets.PopoverWidget : Gtk.Box {
         scroll_box.hscrollbar_policy = Gtk.PolicyType.NEVER;
         scroll_box.add (devices_list);
 
+        var revealer_content_separator = new Gtk.Separator (Gtk.Orientation.HORIZONTAL) {
+            margin_top = 3,
+            margin_bottom = 3
+        };
+
         var revealer_content = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
-        revealer_content.add (new Wingpanel.Widgets.Separator ());
+        revealer_content.add (revealer_content_separator);
         revealer_content.add (scroll_box);
 
         revealer = new Gtk.Revealer ();
@@ -63,7 +68,12 @@ public class BluetoothIndicator.Widgets.PopoverWidget : Gtk.Box {
         add (main_switch);
         add (revealer);
         if (is_in_session) {
-            add (new Wingpanel.Widgets.Separator ());
+            var settings_button_separator = new Gtk.Separator (Gtk.Orientation.HORIZONTAL) {
+                margin_top = 3,
+                margin_bottom = 3
+            };
+
+            add (settings_button_separator);
             add (show_settings_button);
         }
 

--- a/src/Widgets/PopoverWidget.vala
+++ b/src/Widgets/PopoverWidget.vala
@@ -22,7 +22,7 @@ public class BluetoothIndicator.Widgets.PopoverWidget : Gtk.Box {
     public BluetoothIndicator.Services.ObjectManager object_manager { get; construct; }
     public bool is_in_session { get; construct; }
 
-    private Wingpanel.Widgets.Switch main_switch;
+    private Granite.SwitchModelButton main_switch;
     private Gtk.ListBox devices_list;
     private Gtk.Revealer revealer;
 
@@ -36,7 +36,9 @@ public class BluetoothIndicator.Widgets.PopoverWidget : Gtk.Box {
     construct {
         orientation = Gtk.Orientation.VERTICAL;
 
-        main_switch = new Wingpanel.Widgets.Switch (_("Bluetooth"), object_manager.get_global_state ());
+        main_switch = new Granite.SwitchModelButton (_("Bluetooth")) {
+            active = object_manager.get_global_state ()
+        };
         main_switch.get_style_context ().add_class (Granite.STYLE_CLASS_H4_LABEL);
 
         devices_list = new Gtk.ListBox ();


### PR DESCRIPTION
Supersedes #139 
Closes #137 

Adds a tooltip to the indicator and fix some deprecations.

To test, observe tooltip when Bluetooth is on, off and paired.