### PR TITLE
Bluetooth: Improve translatability

### DIFF
--- a/ebt/Dialog/BtReceiver.vala
+++ b/ebt/Dialog/BtReceiver.vala
@@ -109,8 +109,8 @@ public class BtReceiver : Granite.Dialog {
         message_grid.attach (progress_label, 1, 5, 1, 1);
         get_content_area ().add (message_grid);
 
-        add_button ("Close", Gtk.ResponseType.CLOSE);
-        var suggested_button = add_button ("Reject", Gtk.ResponseType.ACCEPT);
+        add_button (_("Close"), Gtk.ResponseType.CLOSE);
+        var suggested_button = add_button (_("Reject"), Gtk.ResponseType.ACCEPT);
         suggested_button.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
         response.connect ((response_id) => {
             if (response_id == Gtk.ResponseType.ACCEPT) {
@@ -233,23 +233,24 @@ public class BtReceiver : Granite.Dialog {
         }
 
         if (seconds < 60) {
-            return ngettext ("%'d second", "%'d seconds", seconds).printf (seconds);
+            return ngettext ("%d second", "%d seconds", seconds).printf (seconds);
         }
 
         int minutes;
         if (seconds < 60 * 60) {
             minutes = (seconds + 30) / 60;
-            return ngettext ("%'d minute", "%'d minutes", minutes).printf (minutes);
+            return ngettext ("%d minute", "%d minutes", minutes).printf (minutes);
         }
 
         int hours = seconds / (60 * 60);
         if (seconds < 60 * 60 * 4) {
             minutes = (seconds - hours * 60 * 60 + 30) / 60;
-            string h = ngettext ("%'u hour", "%'u hours", hours).printf (hours);
-            string m = ngettext ("%'u minute", "%'u minutes", minutes).printf (minutes);
-            return _("%s, %s").printf (h, m); ///TRANSLATORS For example "1 hour, 8 minutes".
+            string h = ngettext ("%u hour", "%u hours", hours).printf (hours);
+            string m = ngettext ("%u minute", "%u minutes", minutes).printf (minutes);
+            ///TRANSLATORS: For example "1 hour, 8 minutes".
+            return _("%s, %s").printf (h, m);
         }
 
-        return ngettext ("approximately %'d hour", "approximately %'d hours", hours).printf (hours);
+        return ngettext ("approximately %d hour", "approximately %d hours", hours).printf (hours);
     }
 }

--- a/ebt/Dialog/BtScan.vala
+++ b/ebt/Dialog/BtScan.vala
@@ -106,7 +106,7 @@ public class BtScan : Granite.Dialog {
             overlaybar.active = manager.check_discovering ();
         });
 
-        add_button ("Close", Gtk.ResponseType.CLOSE);
+        add_button (_("Close"), Gtk.ResponseType.CLOSE);
         response.connect ((response_id) => {
             manager.stop_discovery.begin ();
             destroy ();

--- a/ebt/Dialog/BtSender.vala
+++ b/ebt/Dialog/BtSender.vala
@@ -72,19 +72,19 @@ public class BtSender : Granite.Dialog {
         };
         path_label.get_style_context ().add_class ("primary");
 
-        device_label = new Gtk.Label ("<b>To</b>:") {
+        device_label = new Gtk.Label ("<b>%s</b>:".printf (_("To"))) {
             max_width_chars = 45,
             use_markup = true,
             wrap = true,
             xalign = 0
         };
-        filename_label = new Gtk.Label ("<b>Filename</b>:") {
+        filename_label = new Gtk.Label ("<b>%s</b>:".printf (_("Filename"))) {
             max_width_chars = 45,
             use_markup = true,
             wrap = true,
             xalign = 0
         };
-        rate_label = new Gtk.Label ("<b>Transfer rate:</b>") {
+        rate_label = new Gtk.Label ("<b>%s</b>:".printf (_("Transfer rate"))) {
             max_width_chars = 45,
             use_markup = true,
             wrap = true,
@@ -114,8 +114,8 @@ public class BtSender : Granite.Dialog {
         message_grid.attach (progress_label, 1, 5, 1, 1);
         get_content_area ().add (message_grid);
 
-        add_button ("Close", Gtk.ResponseType.CLOSE);
-        var reject_transfer = add_button ("Cancel", Gtk.ResponseType.CANCEL);
+        add_button (_("Close"), Gtk.ResponseType.CLOSE);
+        var reject_transfer = add_button (_("Cancel"), Gtk.ResponseType.CANCEL);
         reject_transfer.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
 
         response.connect ((response_id) => {
@@ -285,8 +285,8 @@ public class BtSender : Granite.Dialog {
                 ) {
                     badge_icon = new ThemedIcon ("process-error")
                 };
-                bt_retry.add_button ("Cancel", Gtk.ResponseType.CANCEL);
-                var suggested_button = bt_retry.add_button ("Retry", Gtk.ResponseType.ACCEPT);
+                bt_retry.add_button (_("Cancel"), Gtk.ResponseType.CANCEL);
+                var suggested_button = bt_retry.add_button (_("Retry"), Gtk.ResponseType.ACCEPT);
                 suggested_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
 
                 bt_retry.response.connect ((response_id) => {
@@ -319,7 +319,7 @@ public class BtSender : Granite.Dialog {
         var notification = new GLib.Notification ("bluetooth");
         notification.set_icon (new ThemedIcon (device.icon));
         notification.set_priority (NotificationPriority.NORMAL);
-        notification.set_title (_("File transferred successfully "));
+        notification.set_title (_("File transferred successfully"));
         notification.set_body (_("<b>From:</b> %s <b>Send to:</b> %s").printf (file_path.get_path (), device.name));
         ((Gtk.Window)get_toplevel ()).application.send_notification ("io.elementary.bluetooth", notification);
     }
@@ -349,23 +349,24 @@ public class BtSender : Granite.Dialog {
         }
 
         if (seconds < 60) {
-            return ngettext ("%'d second", "%'d seconds", seconds).printf (seconds);
+            return ngettext ("%d second", "%d seconds", seconds).printf (seconds);
         }
 
         int minutes;
         if (seconds < 60 * 60) {
             minutes = (seconds + 30) / 60;
-            return ngettext ("%'d minute", "%'d minutes", minutes).printf (minutes);
+            return ngettext ("%d minute", "%d minutes", minutes).printf (minutes);
         }
 
         int hours = seconds / (60 * 60);
         if (seconds < 60 * 60 * 4) {
             minutes = (seconds - hours * 60 * 60 + 30) / 60;
-            string h = ngettext ("%'u hour", "%'u hours", hours).printf (hours);
-            string m = ngettext ("%'u minute", "%'u minutes", minutes).printf (minutes);
-            return h.concat (", ", m);
+            string h = ngettext ("%u hour", "%u hours", hours).printf (hours);
+            string m = ngettext ("%u minute", "%u minutes", minutes).printf (minutes);
+            ///TRANSLATORS: For example "1 hour, 8 minutes".
+            return _("%s, %s").printf (h, m);
         }
 
-        return ngettext ("approximately %'d hour", "approximately %'d hours", hours).printf (hours);
+        return ngettext ("approximately %d hour", "approximately %d hours", hours).printf (hours);
     }
 }


### PR DESCRIPTION
- Fix untranslatable texts
- Remove unnecessary (?) single quotation mark in the format specifiers
- Remove extra space from translatable texts
- Remove markups from translatable texts as possible
- Don't use `concat()` in case some languages translates `x hours y minutes` into `y minutes x hours`