### PR TITLE
Improved response to power state changes in Switchboard

### DIFF
--- a/src/Services/Manager.vala
+++ b/src/Services/Manager.vala
@@ -115,7 +115,7 @@ public class BluetoothIndicator.Services.ObjectManager : Object {
             ((DBusProxy) adapter).g_properties_changed.connect ((changed, invalid) => {
                 var powered = changed.lookup_value ("Powered", new VariantType ("b"));
                 if (powered != null) {
-                    set_last_state.begin ();
+                    set_global_state.begin (powered.get_boolean ());
                 }
             });
         }
@@ -217,6 +217,7 @@ public class BluetoothIndicator.Services.ObjectManager : Object {
         }
 
         settings.set_boolean ("bluetooth-enabled", state);
+        check_global_state ();
     }
 
     public async void set_last_state () {


### PR DESCRIPTION
Fixes https://github.com/elementary/switchboard-plug-bluetooth/issues/201

This resolves a problem if the user turns off Bluetooth in Switchboard, the Wingpanel indicator would immediately turn it back on (and vice versa). If you would quit Wingpanel, the Switchboard switch would work properly. This PR fixes this "fight" between Switchboard and Wingpanel.

Here is the current situation:


https://user-images.githubusercontent.com/12174852/229206058-774c61be-9a24-4aa1-a1cc-1197c49b0b94.mp4



And here is the situation after this pull request:


https://user-images.githubusercontent.com/12174852/229206084-f00e44a3-806e-4c10-bbf8-bb547c023807.mp4


