### PR TITLE
Fix Bluetooth hang after suspend regression

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -72,7 +72,12 @@ public class BluetoothIndicator.Indicator : Wingpanel.Indicator {
     }
 }
 
-public Wingpanel.Indicator get_indicator (Module module, Wingpanel.IndicatorManager.ServerType server_type) {
+public Wingpanel.Indicator? get_indicator (Module module, Wingpanel.IndicatorManager.ServerType server_type) {
+
+    if (server_type != Wingpanel.IndicatorManager.ServerType.SESSION) {
+        return null;
+    }
+
     debug ("Activating Bluetooth Indicator");
     var indicator = new BluetoothIndicator.Indicator (server_type == Wingpanel.IndicatorManager.ServerType.SESSION);
 


### PR DESCRIPTION
Fixes #192

After commit ce88a7b03231b59c57f832aa656b4763d7d1e77e the Bluetooth indicator no longer works properly in greeter as it leads to an infinite cycle turning on and off.   As the whether Bluetooth should be on or off depends on individual user settings and there is no user defined in the greeter the simplest solution is to just not load it in the greeter.  

If there is a justifiable reason for it to be there then it needs to be rewritten for working in that environment.