### PR TITLE
Revert "Improved response to power state changes in Switchboard (#191)"

### DIFF
--- a/src/Services/Manager.vala
+++ b/src/Services/Manager.vala
@@ -115,7 +115,7 @@ public class BluetoothIndicator.Services.ObjectManager : Object {
             ((DBusProxy) adapter).g_properties_changed.connect ((changed, invalid) => {
                 var powered = changed.lookup_value ("Powered", new VariantType ("b"));
                 if (powered != null) {
-                    set_global_state.begin (powered.get_boolean ());
+                    set_last_state.begin ();
                 }
             });
         }
@@ -217,7 +217,6 @@ public class BluetoothIndicator.Services.ObjectManager : Object {
         }
 
         settings.set_boolean ("bluetooth-enabled", state);
-        check_global_state ();
     }
 
     public async void set_last_state () {


### PR DESCRIPTION
Fixes #192 
Reopens https://github.com/elementary/switchboard-plug-bluetooth/issues/201

This reverts commit ce88a7b03231b59c57f832aa656b4763d7d1e77e. (https://github.com/elementary/wingpanel-indicator-bluetooth/pull/191)

The reopened issue will be refixed in a separate PR as soon as possible.    It is the lesser of two evils.