### PR TITLE
DisplayWidget: gtk4 prep

### DIFF
--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -1,24 +1,12 @@
-/*-
- * Copyright (c) 2015-2021 elementary LLC. (https://elementary.io)
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Library General Public License as published by
- * the Free Software Foundation, either version 2.1 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Library General Public License for more details.
- *
- * You should have received a copy of the GNU Library General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+/*
+* SPDX-License-Identifier: LGPL-2.1-or-later
+* SPDX-FileCopyrightText: 2015-2025 elementary, Inc. (https://elementary.io)
+*/
 
 public class BluetoothIndicator.Widgets.DisplayWidget : Gtk.Spinner {
     public BluetoothIndicator.Services.ObjectManager object_manager { get; construct; }
 
-    private unowned Gtk.StyleContext style_context;
+    private Gtk.GestureMultiPress gesture_click;
 
     public DisplayWidget (BluetoothIndicator.Services.ObjectManager object_manager) {
         Object (object_manager: object_manager);
@@ -32,10 +20,10 @@ public class BluetoothIndicator.Widgets.DisplayWidget : Gtk.Spinner {
         var provider = new Gtk.CssProvider ();
         provider.load_from_resource ("io/elementary/wingpanel/bluetooth/indicator.css");
 
-        style_context = get_style_context ();
-        style_context.add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
-        style_context.add_class ("bluetooth-icon");
-        style_context.add_class ("disabled");
+        Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default (), provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+
+        get_style_context ().add_class ("bluetooth-icon");
+        get_style_context ().add_class ("disabled");
 
         object_manager.global_state_changed.connect ((state, connected) => {
             set_icon ();
@@ -47,16 +35,14 @@ public class BluetoothIndicator.Widgets.DisplayWidget : Gtk.Spinner {
             object_manager.notify["retrieve-finished"].connect (set_icon);
         }
 
-        button_press_event.connect ((e) => {
-            if (e.button == Gdk.BUTTON_MIDDLE) {
-                object_manager.settings.set_boolean (
-                    "bluetooth-enabled",
-                    !object_manager.settings.get_boolean ("bluetooth-enabled")
-                );
-                return Gdk.EVENT_STOP;
-            }
-
-            return Gdk.EVENT_PROPAGATE;
+        gesture_click = new Gtk.GestureMultiPress (this) {
+            button = Gdk.BUTTON_MIDDLE
+        };
+        gesture_click.pressed.connect (() => {
+            object_manager.settings.set_boolean (
+                "bluetooth-enabled",
+                !object_manager.settings.get_boolean ("bluetooth-enabled")
+            );
         });
     }
 
@@ -76,18 +62,18 @@ public class BluetoothIndicator.Widgets.DisplayWidget : Gtk.Spinner {
         string context;
 
         if (state) {
-            style_context.remove_class ("disabled");
+            get_style_context ().remove_class ("disabled");
             context = _("Middle-click to turn Bluetooth off");
             if (connected) {
-                style_context.add_class ("paired");
+                get_style_context ().add_class ("paired");
                 description = _("Bluetooth connected");
             } else {
-                style_context.remove_class ("paired");
+                get_style_context ().remove_class ("paired");
                 description = _("Bluetooth is on");
             }
         } else {
-            style_context.remove_class ("paired");
-            style_context.add_class ("disabled");
+            get_style_context ().remove_class ("paired");
+            get_style_context ().add_class ("disabled");
             description = _("Bluetooth is off");
             context = _("Middle-click to turn Bluetooth on");
         }


### PR DESCRIPTION
* Bump copyright header
* Adding provider to style context is deprecated, add to screen
* Don't cache style context, we'll replace that with `add_css_class` and `remove_css_class` in GTK4
* Use gesture for middle click