### PR TITLE
meson: Correct GETTEXT_PACKAGE

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -28,7 +28,7 @@ wingpanel_indicatorsdir = wingpanel_dep.get_variable('indicatorsdir', pkgconfig_
 
 config_data = configuration_data()
 config_data.set_quoted('LOCALEDIR', prefix / get_option('localedir'))
-config_data.set_quoted('GETTEXT_PACKAGE', meson.project_name() + '-indicator')
+config_data.set_quoted('GETTEXT_PACKAGE', gettext_name)
 config_file = configure_file(
     input: 'src/Config.vala.in',
     output: '@BASENAME@',


### PR DESCRIPTION
Fixes the indicator is shown in English regardless of your system language on OS 9 Daily.
